### PR TITLE
Add avahi dependency

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -73,4 +73,4 @@ jobs:
     displayName: Upload package
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-    condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))
+    condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -14,6 +14,8 @@ gsl:
 - '2.5'
 gst_plugins_base:
 - 1.14.4
+gstreamer:
+- 1.14.4
 numpy:
 - '1.14'
 pin_run_as_build:

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -14,6 +14,8 @@ gsl:
 - '2.5'
 gst_plugins_base:
 - 1.14.4
+gstreamer:
+- 1.14.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 About gstlal
 ============
 
-Home: https://wiki.ligo.org/Computing/GstLAL
+Home: https://lscsoft.docs.ligo.org/gstlal/
 
 Package license: GPL-2.0-or-later
 
 Feedstock license: BSD 3-Clause
 
-Summary: GSTLAL
+Summary: GStreamer for GW data analysis
 
 This package provides a variety of gstreamer elements for
 gravitational-wave data analysis and some libraries to help write

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,22 +1,26 @@
 #!/bin/bash
 
-# conda-forge/conda-forge.github.io#621
-find ${PREFIX} -name "*.la" -delete
-
-# shortcut version of lscsoft/gstlal@027249b601a729eb3a096e7834ee7f5a2c527f43
-export LIBS="-lz"
+set -ex
+mkdir -pv _build
+pushd _build
 
 # only link GSL libraries we actually use
 export GSL_LIBS="-L${PREFIX}/lib -lgsl"
 
 # configure
-./configure \
+${SRC_DIR}/configure \
   --prefix=${PREFIX} \
-  --without-doxygen \
-  --with-html-dir=$(pwd)/tmphtml
+  --with-doxygen=no \
+  --with-html-dir=$(pwd)/tmphtml \
+;
+
+export CPU_COUNT=1
 
 # build
-make -j ${CPU_COUNT}
+make -j ${CPU_COUNT} V=1 VERBOSE=1
 
 # install
-make -j ${CPU_COUNT} install
+make -j ${CPU_COUNT} V=1 VERBOSE=1 install
+
+# test
+make -j ${CPU_COUNT} V=1 VERBOSE=1 check

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,6 +21,3 @@ make -j ${CPU_COUNT} V=1 VERBOSE=1
 
 # install
 make -j ${CPU_COUNT} V=1 VERBOSE=1 install
-
-# test
-make -j ${CPU_COUNT} V=1 VERBOSE=1 check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,13 +9,14 @@ source:
   url: "http://software.ligo.org/lscsoft/source/{{ name }}-{{ version }}.tar.gz"
   sha256: 92926bfc692adea418b8aaaf87663eae10970c78bf4dd0e2fd36c1b68c43392f
   patches:
+    - out-of-tree.patch
     - no-pygtk.patch
     - python-lib-loc.patch
 
 build:
   error_overdepending: true
   error_overlinking: true
-  number: 0
+  number: 1
   skip: true  # [win or py!=27]
 
 requirements:
@@ -26,8 +27,7 @@ requirements:
   host:
     - fftw
     - gsl
-    - gstreamer 1.14.4
-    - gst-orc 0.4.30
+    - gstreamer
     - gst-plugins-base
     - gst-python
     - lal >=6.19.0
@@ -45,8 +45,7 @@ requirements:
     - fftw
     - glib
     - gsl
-    - {{ pin_compatible('gstreamer') }}
-    - gst-orc >=0.4
+    - gstreamer
     - gst-plugins-base
     - gst-python
     - lal >=6.19.0
@@ -62,6 +61,7 @@ requirements:
     - pygobject >=3.14
     - python 2.7
     - python
+    - python-avahi
     - python-lal >=6.19.0
     - python-lalsimulation
     - python-ligo-lw >=1.5.3
@@ -71,29 +71,34 @@ test:
     - gstlal
     - gstlal.bottle
     - gstlal.coherent_null
+    - gstlal.dagfile
     - gstlal.datasource
     - gstlal.elements
-    #- gstlal.matplotlibhelper - broken, see lscsoft/gstlal#15
+    - gstlal.httpinterface
+    - gstlal.matplotlibhelper
     - gstlal.misc
     #- gstlal.multirate_datasource - requires GSTLAL_FIR_WHITEN variable, see below
     - gstlal.pipeio
+    - gstlal.pipeline
     - gstlal.pipeparts
     - gstlal.plotpsd
     - gstlal.plotutil
     - gstlal.reference_psd
+    - gstlal.servicediscovery
     - gstlal.simplehandler
     - gstlal.simulation
     - gstlal.stats
+  requires:
+    - pkg-config
   commands:
     # set variables
     - export TMPDIR=$(python -c "import tempfile; print(tempfile.gettempdir())")
     - export GSTLAL_FIR_WHITEN=0
-    # check last import
+    # check last import (which requires GSTLAL_FIR_WHITEN)
     - ${PYTHON} -c "import gstlal.multirate_datasource"
     # check executables
     - gstlal_asd_txt_from_psd_xml --help
     - gstlal_fake_frames --help
-    #- gstlal_fake_frames_pipe --help <requires gstlal-ugly>
     - gstlal_launch --help
     - gstlal_ligo_data_find_check --help
     - gstlal_play --help
@@ -103,15 +108,17 @@ test:
     - gstlal_psd_xml_from_asd_txt --help
     - gstlal_reference_psd --help
     - gstlal_spectrum_movie --help
+    # check pkg-config
+    - pkg-config --print-errors --modversion gstlal  # [unix]
 
 about:
-  home: "https://wiki.ligo.org/Computing/GstLAL"
+  home: "https://lscsoft.docs.ligo.org/gstlal/"
   dev_url: "https://git.ligo.org/lscsoft/gstlal/"
-  doc_url: "https://docs.ligo.org/lscsoft/gstlal/{{ name }}/{{ name }}.html"
+  doc_url: "https://lscsoft.docs.ligo.org/gstlal/"
   license: "GPL-2.0-or-later"
   license_family: "GPL"
   license_file: "COPYING"
-  summary: "GSTLAL"
+  summary: "GStreamer for GW data analysis"
   description: |
     This package provides a variety of gstreamer elements for
     gravitational-wave data analysis and some libraries to help write

--- a/recipe/out-of-tree.patch
+++ b/recipe/out-of-tree.patch
@@ -1,0 +1,11 @@
+--- lib/gstlal/Makefile.in	2019-12-13 01:12:49.000000000 +0000
++++ lib/gstlal/Makefile.in	2020-02-06 09:37:38.620578196 +0000
+@@ -445,7 +445,7 @@
+ top_builddir = @top_builddir@
+ top_srcdir = @top_srcdir@
+ typelibdir = @typelibdir@
+-AM_CPPFLAGS = -I..
++AM_CPPFLAGS = -I$(abs_srcdir)/..
+ EXTRA_DIST = gstlal_marshal.list gstlal_peakfinder_types.c \
+ 	gstlal_peakfinder.ht gstlal_peakfinder.ct \
+ 	gstlal_peakfinder_top.h gstlal_peakfinder_bottom.h

--- a/recipe/python-lib-loc.patch
+++ b/recipe/python-lib-loc.patch
@@ -25,7 +25,7 @@
 -else
 -	as_fn_error $? "libpython2.7.so not found" "$LINENO" 5
 -fi
-+PYTHON_LIB_SUFFIX=`${SHLIB_EXT} | cut -c2-`
++PYTHON_LIB_SUFFIX=`echo ${SHLIB_EXT} | cut -c2-`
 +PYTHON_LIB_LOC=${PREFIX}/lib
 
 


### PR DESCRIPTION
This PR updates the recipe in a few ways:

- add dependency on `python-avahi`
- remove the `gst-orc` dependency, somehow the built packages end up containing symlinks to `liborc` that contain non-unicode characters somehow - which breaks everything
- fixed a bug in one of the patches


Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
