### PR TITLE
Add sed hack to allow conda to set the python shebang

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,6 +7,10 @@ pushd _build
 # only link GSL libraries we actually use
 export GSL_LIBS="-L${PREFIX}/lib -lgsl"
 
+# replace '/usr/bin/env python3' with '/usr/bin/python'
+# so that conda-build will then replace it with the $PREFIX/bin/python
+sed -i.tmp 's/\/usr\/bin\/env python3/\/usr\/bin\/python/g' ${SRC_DIR}/bin/gstlal_*
+
 # configure
 ${SRC_DIR}/configure \
   --enable-gtk-doc-html=no \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ build:
     # but aren't actually directly linked against
     - gobject-introspection
     - gst-python
-  number: 0
+  number: 1
   # SyntaxErrors on python>=3.7 use of 'async' reserved keyword
   skip: true  # [win or py>36]
 


### PR DESCRIPTION
This PR adds a `sed` command to patch all of the python scripts in such a way that allows `conda-build` to override the shebang on _install_. This means that the scripts installed in a users's environment will end up with a shebang that looks like

```python
#!/path/to/prefix/bin/python
```

which is more robust relative to `PATH` manipulation etc.

@myNameIsPatrick, please confirm that this is kosher.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
