### PR TITLE
Pin pygobject below 3.36

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ build:
     - gobject-introspection
     - gst-python
     - numpy
-  number: 5
+  number: 6
   skip: true  # [win]
 
 requirements:
@@ -60,7 +60,7 @@ requirements:
     - liblalinspiral >={{ lalinspiral_version }}
     - liblalsimulation >={{ lalsimulation_version }}
     - numpy
-    - pygobject >=3.22
+    - pygobject >=3.22,<3.36
     - python
     - python-lal
     - python-ligo-lw >={{ ligo_lw_version }}
@@ -87,7 +87,7 @@ requirements:
     - pandas
     - pluggy >={{ pluggy_version }}
     - pyfftw
-    - pygobject >=3.22
+    - pygobject >=3.22,<3.36
     - python
     - python-avahi
     - python-htcondor >={{ python_condor_version }}


### PR DESCRIPTION
This PR pins pygobject below 3.36, see https://git.ligo.org/lscsoft/gstlal/-/issues/67.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
